### PR TITLE
Add GIS geo-tool scaffold and setup instructions

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,39 @@
+# LibreChat × GIS 연결 가이드
+
+## 1) geo-tool 실행
+```bash
+cd geo-tool
+npm i
+npm run dev   # http://localhost:8787
+# 확인: http://localhost:8787/ui.html
+#       http://localhost:8787/geo/sample
+```
+
+## 2) LibreChat에서 아티팩트로 지도 띄우기
+
+* 대화창에 아래 문장을 그대로 입력:
+
+  > "다음 코드를 **아티팩트**로 렌더링해줘. 컴포넌트는 `GisIFrame`이고, 코드는 곧 붙여넣을게."
+* 이어서 `artifacts/GisIFrame.tsx` 코드 전부를 붙여넣기
+* 기본 src는 `http://host.docker.internal:8787/ui.html?src=/geo/sample`
+
+  * Linux에서는 `http://172.17.0.1:8787/ui.html?src=/geo/sample` 권장
+
+## 3) 데이터/뷰 옵션
+
+* GeoJSON 교체: `?src=/geo/sample` → `?src=http://host.docker.internal:8787/geo/points?bbox=126.8,37.45,127.2,37.7&n=1000`
+* 초기 영역(BBOX): `&bbox=minLon,minLat,maxLon,maxLat`
+* 외부 WMS(간이 프록시): `http://host.docker.internal:8787/wms?url=${encodeURIComponent(WMS_URL)}`
+
+## 4) 검증 체크리스트
+
+* [ ] `http://localhost:8787/ui.html` 에서 지도가 보인다
+* [ ] LibreChat 아티팩트에 IFrame 지도가 렌더된다
+* [ ] `src=` 변경 시 GeoJSON 레이어가 바뀐다
+
+## 5) 트러블슈팅
+
+* 아티팩트에서 빈 화면: `src` 도메인 접근가능 여부(CORS/포트) 확인
+* Docker 내부에서 호스트 접근 안됨: Mac/Win은 `host.docker.internal`, Linux는 `172.17.0.1`
+* 외부 WMS가 CORS 차단: `/wms?url=` 프록시 사용
+

--- a/artifacts/GisIFrame.tsx
+++ b/artifacts/GisIFrame.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+type Props = {
+  src?: string;           // ex) "http://host.docker.internal:8787/ui.html?src=/geo/sample"
+  height?: string | number;
+};
+
+export default function GisIFrame({
+  src = "http://host.docker.internal:8787/ui.html?src=/geo/sample",
+  height = "60vh",
+}: Props) {
+  // \uB9AC\uB205\uC2A4 \uD638\uC2A4\uD2B8 \uB300\uC548: http://172.17.0.1:8787/ui.html
+  return (
+    <div style={{ width: "100%", height, borderRadius: 12, overflow: "hidden", border: "1px solid #e5e7eb" }}>
+      <iframe
+        src={src}
+        title="GIS"
+        style={{ width: "100%", height: "100%", border: "0" }}
+        allow="geolocation *; clipboard-read; clipboard-write"
+      />
+    </div>
+  );
+}

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,5 @@
+version: "3.8"
+services:
+  api:
+    extra_hosts:
+      - "host.docker.internal:172.17.0.1"

--- a/geo-tool/package.json
+++ b/geo-tool/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "geo-tool",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "tsx watch server.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "node-fetch": "^3.3.2"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "tsx": "^4.7.0",
+    "typescript": "^5.5.4"
+  }
+}

--- a/geo-tool/public/ui.html
+++ b/geo-tool/public/ui.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <title>GIS UI</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <style>
+    html,body,#app{height:100%;margin:0}
+    #map{height:100%;width:100%}
+    .toolbar{position:absolute;z-index:1000;top:10px;left:10px;background:#fff;border-radius:8px;padding:8px;box-shadow:0 2px 12px rgba(0,0,0,.15);font-family:system-ui,Arial}
+    .toolbar input{width:280px}
+  </style>
+</head>
+<body>
+  <div id="app">
+    <div class="toolbar">
+      <div><strong>GIS UI</strong></div>
+      <div style="margin-top:6px">
+        GeoJSON URL:
+        <input id="src" placeholder="/geo/sample" />
+        <button id="load">Load</button>
+        <button id="fit">Fit</button>
+      </div>
+    </div>
+    <div id="map"></div>
+  </div>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script>
+    const qs = new URLSearchParams(location.search);
+    const srcParam = qs.get("src") || "/geo/sample";
+    const bboxParam = qs.get("bbox"); // "minLon,minLat,maxLon,maxLat"
+
+    const map = L.map("map", { zoomControl: true }).setView([37.5665,126.9780], 11);
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      attribution:'&copy; OpenStreetMap contributors'
+    }).addTo(map);
+
+    const layer = L.geoJSON(null).addTo(map);
+    const $src = document.getElementById("src");
+    const $load = document.getElementById("load");
+    const $fit = document.getElementById("fit");
+    $src.value = srcParam;
+
+    function fitToData() {
+      try {
+        const b = layer.getBounds();
+        if (b.isValid()) map.fitBounds(b.pad(0.2));
+      } catch (e) {}
+    }
+
+    async function loadGeoJSON(url) {
+      try {
+        const res = await fetch(url);
+        const data = await res.json();
+        layer.clearLayers();
+        layer.addData(data);
+        fitToData();
+      } catch (e) {
+        alert("Failed to load GeoJSON");
+      }
+    }
+
+    $load.onclick = () => loadGeoJSON($src.value);
+    $fit.onclick = () => fitToData();
+
+    if (bboxParam) {
+      const [minX,minY,maxX,maxY] = bboxParam.split(",").map(Number);
+      if ([minX,minY,maxX,maxY].every(v => !isNaN(v))) {
+        const sw = L.latLng(minY, minX), ne = L.latLng(maxY, maxX);
+        map.fitBounds(L.latLngBounds(sw, ne));
+      }
+    }
+    loadGeoJSON(srcParam);
+  </script>
+</body>
+</html>

--- a/geo-tool/sample/sample.geojson
+++ b/geo-tool/sample/sample.geojson
@@ -1,0 +1,16 @@
+{
+  "type": "FeatureCollection",
+  "name": "seoul_mini",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": { "name": "Seoul City Hall" },
+      "geometry": { "type": "Point", "coordinates": [126.9779692, 37.566535] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Gangnam Station" },
+      "geometry": { "type": "Point", "coordinates": [127.027621, 37.497942] }
+    }
+  ]
+}

--- a/geo-tool/server.ts
+++ b/geo-tool/server.ts
@@ -1,0 +1,74 @@
+import express from "express";
+import cors from "cors";
+import path from "path";
+import { fileURLToPath } from "url";
+import fs from "fs";
+import fetch from "node-fetch";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const app = express();
+const PORT = Number(process.env.PORT || 8787);
+
+app.use(cors());
+app.use(express.json());
+app.use("/public", express.static(path.join(__dirname, "public")));
+
+app.get("/health", (_, res) => res.json({ ok: true }));
+
+// \uC0D8\uD50C GeoJSON \uC81C\uACF5
+app.get("/geo/sample", (_, res) => {
+  const p = path.join(__dirname, "sample", "sample.geojson");
+  const text = fs.readFileSync(p, "utf-8");
+  res.setHeader("Content-Type", "application/geo+json; charset=utf-8");
+  res.send(text);
+});
+
+// \uC784\uC758 \uD3EC\uC778\uD2B8 \uC0DD\uC131(bbox=minLon,minLat,maxLon,maxLat)
+app.get("/geo/points", (req, res) => {
+  const bbox = String(req.query.bbox || "");
+  const n = Math.min(Number(req.query.n || 200), 2000);
+  const parts = bbox.split(",").map(Number);
+  if (parts.length !== 4 || parts.some(isNaN)) {
+    return res.status(400).json({ error: "bbox=minLon,minLat,maxLon,maxLat" });
+  }
+  const [minX, minY, maxX, maxY] = parts;
+  const features = Array.from({ length: n }).map((_, i) => ({
+    type: "Feature",
+    properties: { id: i + 1 },
+    geometry: {
+      type: "Point",
+      coordinates: [
+        Math.random() * (maxX - minX) + minX,
+        Math.random() * (maxY - minY) + minY
+      ]
+    }
+  }));
+  res.json({ type: "FeatureCollection", features });
+});
+
+// \uAC04\uC774 WMS/\uD0C0\uC77C \uD504\uB85D\uC2DC (GET /wms?url=ENCODED_URL)
+app.get("/wms", async (req, res) => {
+  const raw = String(req.query.url || "");
+  if (!raw) return res.status(400).json({ error: "url required" });
+  try {
+    const target = decodeURIComponent(raw);
+    const r = await fetch(target);
+    const buf = Buffer.from(await r.arrayBuffer());
+    res.setHeader("Content-Type", r.headers.get("content-type") || "application/octet-stream");
+    res.send(buf);
+  } catch (e) {
+    res.status(502).json({ error: "proxy_failed" });
+  }
+});
+
+// self-contained \uC9C0\uB3C4 UI
+app.get("/ui.html", (_, res) => {
+  res.sendFile(path.join(__dirname, "public", "ui.html"));
+});
+
+app.listen(PORT, () => {
+  console.log(`[geo-tool] listening on http://localhost:${PORT}`);
+});
+

--- a/geo-tool/tsconfig.json
+++ b/geo-tool/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["server.ts"]
+}


### PR DESCRIPTION
## Summary
- add Express-based geo-tool with sample GeoJSON, WMS proxy, and Leaflet UI
- introduce GisIFrame artifact for embedding map in LibreChat
- document setup and host mapping

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 341 problems (194 errors, 147 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689c01dbb6348327a29e68c83aff8113